### PR TITLE
Enhance profiling stats and display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,6 @@ typings/
 runs/
 dist/
 build/
+profiles/
 
 !.yalc/react-redux/dist/

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "redux": "^5.0.0",
     "reselect": "^5.0.0",
     "seedrandom": "^3.0.5",
+    "source-map-js": "^1.2.1",
     "tsx": "^4.19.2",
     "use-sync-external-store": "latest",
     "yargs": "^17"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "yargs": "^17"
   },
   "devDependencies": {
+    "@ast-grep/napi": "^0.43.0",
     "@types/cli-table2": "^0.2.3",
     "@types/express": "^4.17.17",
     "@types/fs-extra": "^9.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       seedrandom:
         specifier: ^3.0.5
         version: 3.0.5
+      source-map-js:
+        specifier: ^1.2.1
+        version: 1.2.1
       tsx:
         specifier: ^4.19.2
         version: 4.22.3
@@ -418,6 +421,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@solidjs/signals@0.9.3':
+    resolution: {integrity: sha512-mb8MfIPy2sKuAJEurfC0BeU/yLruNIlt6QBsF0kOPkui1Xq/n9vfVIy19JbGA5jRpXM2Cb+JJe8WPLUznI263A==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1722,6 +1728,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@solidjs/signals@0.9.3': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -2592,6 +2600,7 @@ snapshots:
 
   react-redux@file:.yalc/react-redux(@types/react@19.2.15)(react@19.2.6)(redux@5.0.1):
     dependencies:
+      '@solidjs/signals': 0.9.3
       '@types/use-sync-external-store': 0.0.6
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
         specifier: ^17
         version: 17.7.2
     devDependencies:
+      '@ast-grep/napi':
+        specifier: ^0.43.0
+        version: 0.43.0
       '@types/cli-table2':
         specifier: ^0.2.3
         version: 0.2.6
@@ -125,6 +128,68 @@ importers:
         version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.3)
 
 packages:
+
+  '@ast-grep/napi-darwin-arm64@0.43.0':
+    resolution: {integrity: sha512-JBWYRNJsQ/8yfcMDARFxcl1fVZ6+kv3sHB+ClKgSCe9DNoLvGQfqGr9UGRrNOModvXY6cX+c87iAPqPGftUUiw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ast-grep/napi-darwin-x64@0.43.0':
+    resolution: {integrity: sha512-oqE/bC/uAEctnAbzqobplidExsPym4CQq7JDVD9HpkHpDHzMzPBF69whv/Qu0ZwrkXr48GCMKO5G6p+OB5n+kQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ast-grep/napi-linux-arm64-gnu@0.43.0':
+    resolution: {integrity: sha512-yJSRPxwwrvVW94J2rtaatcixSAGWcSaHNbAh6soXD6HXgq6I7uMc+cyMnJstFL789yd6Pu3QIhTlpD9VY0oYhw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/napi-linux-arm64-musl@0.43.0':
+    resolution: {integrity: sha512-mknXLDsf66HvT/JEl18ZQSvR7/qWgWfqh3eHuVRqD2lE6cKBDXRnAzx9ZNZkUnL2Z5ph54Yk8dKVu09k45cegA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@ast-grep/napi-linux-x64-gnu@0.43.0':
+    resolution: {integrity: sha512-KM6M5KKFsHG9Y7VKCKnMsWQQ1sYwj/SPdyr91SKp66AeFJ5xMtXb13WVQ3Joe9NEsi84dzzOBIJgMddz+UMvQw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/napi-linux-x64-musl@0.43.0':
+    resolution: {integrity: sha512-NfjI74m7CEEOsLi7ZkYwcxY10CfKIHPHRrr9aqMulmnrC4FGvxQMk1qpDrTqkjmEd8LdZt3PsPrmBa8AZCErew==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@ast-grep/napi-win32-arm64-msvc@0.43.0':
+    resolution: {integrity: sha512-8qwXz3oogh834bXmNLtgsQYsuQi4ZDu4e1He/q+ENhVfjIr4IZRAUc1CoKZgWn+ZSE+B0NJJIxT8Vre2l0Q1Lg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ast-grep/napi-win32-ia32-msvc@0.43.0':
+    resolution: {integrity: sha512-wUI/B9QNPzi0K7LlyO7eWvwhqFChM6+O4r5dfBfnOlkP1s/AZ04FdYaC9KAZiODE4FCWbeHbfO03RYOdWeF6eg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ast-grep/napi-win32-x64-msvc@0.43.0':
+    resolution: {integrity: sha512-GsGIwYiThKiK9XPGBEguZAs4aIBgv6+DgosBs6ve2a3L390AaLqitoc+bbRz4Eu51URlFKmNP7TtvnAJbMi8QQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ast-grep/napi@0.43.0':
+    resolution: {integrity: sha512-dPugC04xwgk3gJl17jJvTjVjx1IXtWI9EcEQ0szlh0jg1UfvGDdZJo9/S9Pk7gzGBNd2bW8hIL3dG6K4T8PEJA==}
+    engines: {node: '>= 10'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1551,6 +1616,45 @@ packages:
     engines: {node: '>=12'}
 
 snapshots:
+
+  '@ast-grep/napi-darwin-arm64@0.43.0':
+    optional: true
+
+  '@ast-grep/napi-darwin-x64@0.43.0':
+    optional: true
+
+  '@ast-grep/napi-linux-arm64-gnu@0.43.0':
+    optional: true
+
+  '@ast-grep/napi-linux-arm64-musl@0.43.0':
+    optional: true
+
+  '@ast-grep/napi-linux-x64-gnu@0.43.0':
+    optional: true
+
+  '@ast-grep/napi-linux-x64-musl@0.43.0':
+    optional: true
+
+  '@ast-grep/napi-win32-arm64-msvc@0.43.0':
+    optional: true
+
+  '@ast-grep/napi-win32-ia32-msvc@0.43.0':
+    optional: true
+
+  '@ast-grep/napi-win32-x64-msvc@0.43.0':
+    optional: true
+
+  '@ast-grep/napi@0.43.0':
+    optionalDependencies:
+      '@ast-grep/napi-darwin-arm64': 0.43.0
+      '@ast-grep/napi-darwin-x64': 0.43.0
+      '@ast-grep/napi-linux-arm64-gnu': 0.43.0
+      '@ast-grep/napi-linux-arm64-musl': 0.43.0
+      '@ast-grep/napi-linux-x64-gnu': 0.43.0
+      '@ast-grep/napi-linux-x64-musl': 0.43.0
+      '@ast-grep/napi-win32-arm64-msvc': 0.43.0
+      '@ast-grep/napi-win32-ia32-msvc': 0.43.0
+      '@ast-grep/napi-win32-x64-msvc': 0.43.0
 
   '@babel/code-frame@7.29.7':
     dependencies:

--- a/runBenchmarks.ts
+++ b/runBenchmarks.ts
@@ -18,6 +18,8 @@ import {
   V8CpuProfile,
 } from './utils/server'
 
+import type { InstrumentationStats } from './src/common/instrumentation'
+
 const readFolderNames = (searchDir: string) => {
   return glob.sync('*/', { cwd: searchDir }).map((s) => s.replace('/', ''))
 }
@@ -65,6 +67,12 @@ const args = yargs(process.argv.slice(2))
   })
   .option('save-profiles', {
     describe: 'Save .cpuprofile files to ./profiles/ directory',
+    type: 'boolean',
+    default: false,
+  })
+  .option('instrument', {
+    alias: 'i',
+    describe: 'Collect dispatch-cycle instrumentation (build with --instrument)',
     type: 'boolean',
     default: false,
   })
@@ -266,6 +274,7 @@ interface BenchmarkStats {
   }
   wallTime: number
   moduleBreakdown?: ModuleBreakdown
+  instrumentation?: InstrumentationStats
 }
 
 function calculateBenchmarkStats(
@@ -338,7 +347,10 @@ function calculateBenchmarkStats(
     moduleBreakdown = computeModuleBreakdown(cpuProfile, bundlePath)
   }
 
-  return { cdp, react, dispatch, wallTime, moduleBreakdown }
+  // Instrumentation stats (pass through)
+  const instrumentation = results.instrumentationStats ?? undefined
+
+  return { cdp, react, dispatch, wallTime, moduleBreakdown, instrumentation }
 }
 
 // --- Output ---
@@ -346,7 +358,8 @@ function calculateBenchmarkStats(
 function printBenchmarkResults(
   benchmark: string,
   versionPerfEntries: Record<string, BenchmarkStats>,
-  showProfile: boolean
+  showProfile: boolean,
+  showInstrumentation: boolean
 ) {
   console.log(`\n${chalk.bold.underline(benchmark)}`)
   console.log(chalk.dim('  All times in ms'))
@@ -418,6 +431,40 @@ function printBenchmarkResults(
     }
     console.log(profileTable.toString())
   }
+
+  // Instrumentation table (only when --instrument)
+  if (showInstrumentation) {
+    const hasAnyInst = versions.some(v => versionPerfEntries[v].instrumentation)
+    if (hasAnyInst) {
+      const instTable: any = new Table({
+        head: ['Version', 'Reducer', 'Notify', 'Callbacks', 'Selector', 'Sel#', 'EqCheck', 'Eq#', 'Reconcile', 'Rec#', 'SigSel', 'Sig#'],
+        style: { head: ['cyan'] },
+        colAligns,
+      })
+      for (const version of versions) {
+        const inst = versionPerfEntries[version].instrumentation
+        if (inst) {
+          instTable.push([
+            version,
+            inst.reducerTime.toFixed(1),
+            inst.notifyTime.toFixed(1),
+            inst.callbackCount,
+            inst.selectorTime.toFixed(1),
+            inst.selectorCount,
+            inst.equalityCheckTime.toFixed(1),
+            inst.equalityCheckCount,
+            inst.reconcileTime.toFixed(1),
+            inst.reconcileCount,
+            inst.signalSelectorTime.toFixed(1),
+            inst.signalSelectorCount,
+          ])
+        } else {
+          instTable.push([version, ...Array(11).fill('N/A')])
+        }
+      }
+      console.log(instTable.toString())
+    }
+  }
 }
 
 function saveCpuProfile(
@@ -443,6 +490,7 @@ async function runBenchmarks({
   json: jsonOutput,
   profile: enableProfile,
   'save-profiles': saveProfiles,
+  instrument: enableInstrumentation,
 }: {
   scenarios: string[]
   versions: string[]
@@ -451,6 +499,7 @@ async function runBenchmarks({
   json: boolean
   profile: boolean
   'save-profiles': boolean
+  instrument: boolean
 }) {
   if (!jsonOutput) {
     console.log('Scenarios: ', scenarios)
@@ -501,7 +550,8 @@ async function runBenchmarks({
           browser,
           URL,
           length * 1000,
-          enableProfile
+          enableProfile,
+          enableInstrumentation
         )
 
         if (saveProfiles && results.cpuProfile) {
@@ -521,7 +571,7 @@ async function runBenchmarks({
     }
 
     if (!jsonOutput) {
-      printBenchmarkResults(scenario, versionPerfEntries, enableProfile)
+      printBenchmarkResults(scenario, versionPerfEntries, enableProfile, enableInstrumentation)
     }
 
     allResults[scenario] = versionPerfEntries

--- a/runBenchmarks.ts
+++ b/runBenchmarks.ts
@@ -8,12 +8,14 @@ import Table from 'cli-table2'
 import glob from 'glob'
 import yargs from 'yargs/yargs'
 import chalk from 'chalk'
+import { SourceMapConsumer, type RawSourceMap } from 'source-map-js'
 
 import {
   capturePageStats,
   runServer,
   PageStatsResult,
   RenderResult,
+  V8CpuProfile,
 } from './utils/server'
 
 const readFolderNames = (searchDir: string) => {
@@ -50,8 +52,197 @@ const args = yargs(process.argv.slice(2))
     type: 'boolean',
     default: true,
   })
+  .option('json', {
+    describe: 'Output results as JSON',
+    type: 'boolean',
+    default: false,
+  })
+  .option('profile', {
+    alias: 'p',
+    describe: 'Enable V8 CPU profiling with per-module attribution',
+    type: 'boolean',
+    default: false,
+  })
+  .option('save-profiles', {
+    describe: 'Save .cpuprofile files to ./profiles/ directory',
+    type: 'boolean',
+    default: false,
+  })
   .help('h')
   .alias('h', 'help')
+
+// --- Percentile helper ---
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0
+  const idx = Math.ceil((p / 100) * sorted.length) - 1
+  return sorted[Math.max(0, idx)]
+}
+
+// --- Module attribution ---
+
+type ModuleCategory =
+  | 'react-dom'
+  | 'react'
+  | 'react-redux'
+  | 'redux/toolkit'
+  | 'app'
+  | 'other'
+
+function classifySourcePath(originalSource: string): ModuleCategory {
+  const s = originalSource.replace(/\\/g, '/')
+  // Order matters: more specific matches first
+  if (s.includes('/react-dom/')) return 'react-dom'
+  if (s.includes('/react-redux/') || s.includes('/react-redux-'))
+    return 'react-redux'
+  if (
+    s.includes('/@reduxjs/toolkit/') ||
+    s.includes('/node_modules/redux/') ||
+    s.includes('/node_modules/reselect/') ||
+    s.includes('/node_modules/immer/')
+  )
+    return 'redux/toolkit'
+  if (
+    s.includes('/node_modules/react/') ||
+    s.includes('/node_modules/scheduler/')
+  )
+    return 'react'
+  if (
+    s.includes('/scenarios/') ||
+    s.includes('/common/') ||
+    s.includes('/src/')
+  )
+    return 'app'
+  return 'other'
+}
+
+// Classify non-bundle profile nodes (browser internals, GC, extensions, etc.)
+type NonBundleCategory = 'idle' | 'gc' | 'browser'
+
+function classifyNonBundleNode(
+  functionName: string,
+  url: string
+): NonBundleCategory {
+  if (
+    functionName === '(idle)' ||
+    functionName === '(root)' ||
+    functionName === ''
+  )
+    return 'idle'
+  if (functionName === '(garbage collector)' || functionName.includes('GC'))
+    return 'gc'
+  return 'browser'
+}
+
+export interface ModuleBreakdown {
+  'react-dom': number
+  react: number
+  'react-redux': number
+  'redux/toolkit': number
+  app: number
+  other: number
+  idle: number
+  gc: number
+  browser: number
+}
+
+function extractInlineSourceMap(bundlePath: string): RawSourceMap | null {
+  const content = fs.readFileSync(bundlePath, 'utf-8')
+  const marker = '//# sourceMappingURL=data:application/json;charset=utf-8;base64,'
+  const idx = content.lastIndexOf(marker)
+  if (idx === -1) return null
+  const base64 = content.slice(idx + marker.length).trim()
+  const json = Buffer.from(base64, 'base64').toString('utf-8')
+  return JSON.parse(json)
+}
+
+function computeModuleBreakdown(
+  profile: V8CpuProfile,
+  bundlePath: string
+): ModuleBreakdown {
+  const breakdown: ModuleBreakdown = {
+    'react-dom': 0,
+    react: 0,
+    'react-redux': 0,
+    'redux/toolkit': 0,
+    app: 0,
+    other: 0,
+    idle: 0,
+    gc: 0,
+    browser: 0,
+  }
+
+  const rawMap = extractInlineSourceMap(bundlePath)
+  if (!rawMap) {
+    console.warn(chalk.yellow(`  No inline source map found in ${bundlePath}`))
+    return breakdown
+  }
+
+  const consumer = new SourceMapConsumer(rawMap)
+
+  // Build node map for lookup
+  const nodeMap = new Map<number, V8ProfileNode>()
+  for (const node of profile.nodes) {
+    nodeMap.set(node.id, node)
+  }
+
+  // Compute self time per node from samples + timeDeltas
+  const selfTime = new Map<number, number>()
+  if (profile.samples && profile.timeDeltas) {
+    for (let i = 0; i < profile.samples.length; i++) {
+      const nodeId = profile.samples[i]
+      const delta = profile.timeDeltas[i]
+      selfTime.set(nodeId, (selfTime.get(nodeId) ?? 0) + delta)
+    }
+  } else {
+    // Fallback: use hitCount (less precise)
+    for (const node of profile.nodes) {
+      if (node.hitCount) {
+        selfTime.set(node.id, node.hitCount)
+      }
+    }
+  }
+
+  // Determine the bundle URL to match against callFrame.url
+  // The bundle is served at e.g. http://localhost:9999/{version}/{scenario}/index.js
+  const bundleFilename = 'index.js'
+
+  for (const node of profile.nodes) {
+    const time = selfTime.get(node.id) ?? 0
+    if (time === 0) continue
+
+    const { url, lineNumber, columnNumber } = node.callFrame
+
+    // Non-bundle nodes: browser internals, idle, GC
+    if (!url.endsWith(bundleFilename)) {
+      const cat = classifyNonBundleNode(node.callFrame.functionName, url)
+      breakdown[cat] += time
+      continue
+    }
+
+    // V8 uses 0-based lines, source-map-js uses 1-based
+    const pos = consumer.originalPositionFor({
+      line: lineNumber + 1,
+      column: columnNumber,
+    })
+
+    if (pos.source) {
+      const category = classifySourcePath(pos.source)
+      breakdown[category] += time
+    } else {
+      breakdown.other += time
+    }
+  }
+
+  // Convert from μs to ms
+  for (const key of Object.keys(breakdown) as ModuleCategory[]) {
+    breakdown[key] = breakdown[key] / 1000
+  }
+
+  return breakdown
+}
+
+// --- Stats types ---
 
 interface BenchmarkStats {
   cdp: {
@@ -63,6 +254,9 @@ interface BenchmarkStats {
   react: {
     mountTime: number | null
     avgUpdateTime: number | null
+    p50UpdateTime: number | null
+    p95UpdateTime: number | null
+    totalRenderTime: number
     renderCount: number
   }
   dispatch: {
@@ -71,12 +265,15 @@ interface BenchmarkStats {
     avgTime: number
   }
   wallTime: number
+  moduleBreakdown?: ModuleBreakdown
 }
 
 function calculateBenchmarkStats(
-  results: PageStatsResult
+  results: PageStatsResult,
+  bundlePath?: string
 ): BenchmarkStats {
-  const { cdpMetrics, dispatchStats, reactTimingEntries, wallTime } = results
+  const { cdpMetrics, dispatchStats, reactTimingEntries, wallTime, cpuProfile } =
+    results
 
   // CDP metrics (seconds from CDP, convert to ms for display)
   const cdp = {
@@ -99,15 +296,32 @@ function calculateBenchmarkStats(
 
   const mountTime = mountEntry?.actualTime ?? null
 
+  const totalRenderTime = reactTimingEntries.reduce(
+    (sum, entry) => sum + entry.actualTime,
+    0
+  )
+
+  const updateTimes = updateEntries
+    .map((e) => e.actualTime)
+    .sort((a, b) => a - b)
+
   const avgUpdateTime =
-    updateEntries.length > 0
-      ? updateEntries.reduce((sum, entry) => sum + entry.actualTime, 0) /
-        updateEntries.length
+    updateTimes.length > 0
+      ? updateTimes.reduce((sum, t) => sum + t, 0) / updateTimes.length
       : null
+
+  const p50UpdateTime =
+    updateTimes.length > 0 ? percentile(updateTimes, 50) : null
+
+  const p95UpdateTime =
+    updateTimes.length > 0 ? percentile(updateTimes, 95) : null
 
   const react = {
     mountTime,
     avgUpdateTime,
+    p50UpdateTime,
+    p95UpdateTime,
+    totalRenderTime,
     renderCount: reactTimingEntries.length,
   }
 
@@ -118,35 +332,55 @@ function calculateBenchmarkStats(
     avgTime: dispatchStats.avgTime,
   }
 
-  return { cdp, react, dispatch, wallTime }
+  // Module breakdown from V8 CPU profile
+  let moduleBreakdown: ModuleBreakdown | undefined
+  if (cpuProfile && bundlePath) {
+    moduleBreakdown = computeModuleBreakdown(cpuProfile, bundlePath)
+  }
+
+  return { cdp, react, dispatch, wallTime, moduleBreakdown }
 }
+
+// --- Output ---
 
 function printBenchmarkResults(
   benchmark: string,
-  versionPerfEntries: Record<string, BenchmarkStats>
+  versionPerfEntries: Record<string, BenchmarkStats>,
+  showProfile: boolean
 ) {
   console.log(`\nResults for benchmark ${benchmark}:`)
 
-  const table: any = new Table({
-    head: [
-      'Version',
-      'Script\n(ms)',
-      'Task\n(ms)',
-      'Layout\n(ms)',
-      'Style\n(ms)',
-      'Mount\n(ms)',
-      'Avg Upd\n(ms)',
-      'Renders',
-      'Dispatches\n(avg ms)',
-    ],
-  })
+  const head = [
+    'Version',
+    'Script\n(ms)',
+    'Task\n(ms)',
+    'Layout\n(ms)',
+    'Style\n(ms)',
+    'Mount\n(ms)',
+    'Avg Upd\n(ms)',
+    'p95 Upd\n(ms)',
+    'Renders',
+    'Dispatches\n(avg ms)',
+  ]
+
+  if (showProfile) {
+    head.push(
+      'react-dom\n(ms)',
+      'react\n(ms)',
+      'react-redux\n(ms)',
+      'redux/tk\n(ms)',
+      'app\n(ms)'
+    )
+  }
+
+  const table: any = new Table({ head })
 
   Object.keys(versionPerfEntries)
     .sort()
     .forEach((version) => {
       const stats = versionPerfEntries[version]
 
-      table.push([
+      const row: (string | number)[] = [
         version,
         stats.cdp.scriptDuration.toFixed(0),
         stats.cdp.taskDuration.toFixed(0),
@@ -154,36 +388,83 @@ function printBenchmarkResults(
         stats.cdp.styleDuration.toFixed(0),
         stats.react.mountTime?.toFixed(1) ?? 'N/A',
         stats.react.avgUpdateTime?.toFixed(1) ?? 'N/A',
+        stats.react.p95UpdateTime?.toFixed(1) ?? 'N/A',
         stats.react.renderCount,
         `${stats.dispatch.count} (${stats.dispatch.avgTime.toFixed(2)})`,
-      ])
+      ]
+
+      if (showProfile && stats.moduleBreakdown) {
+        const mb = stats.moduleBreakdown
+        row.push(
+          mb['react-dom'].toFixed(0),
+          mb.react.toFixed(0),
+          mb['react-redux'].toFixed(0),
+          mb['redux/toolkit'].toFixed(0),
+          mb.app.toFixed(0)
+        )
+      } else if (showProfile) {
+        row.push('N/A', 'N/A', 'N/A', 'N/A', 'N/A')
+      }
+
+      table.push(row)
     })
 
   console.log(table.toString())
 }
+
+function saveCpuProfile(
+  profile: V8CpuProfile,
+  scenario: string,
+  version: string
+) {
+  const dir = path.resolve('profiles')
+  fs.mkdirSync(dir, { recursive: true })
+  const filename = `${scenario}_${version}.cpuprofile`
+  const filepath = path.join(dir, filename)
+  fs.writeFileSync(filepath, JSON.stringify(profile))
+  console.log(`    Saved profile: ${filepath}`)
+}
+
+// --- Main ---
 
 async function runBenchmarks({
   scenarios,
   versions,
   length,
   headless,
+  json: jsonOutput,
+  profile: enableProfile,
+  'save-profiles': saveProfiles,
 }: {
   scenarios: string[]
   versions: string[]
   length: number
   headless: boolean
+  json: boolean
+  profile: boolean
+  'save-profiles': boolean
 }) {
-  console.log('Scenarios: ', scenarios)
+  if (!jsonOutput) {
+    console.log('Scenarios: ', scenarios)
+  }
+
   const distFolder = path.resolve('dist')
   const server = await runServer(9999, distFolder)
+
+  const allResults: Record<string, Record<string, BenchmarkStats>> = {}
 
   for (let scenario of scenarios) {
     const versionPerfEntries: Record<string, BenchmarkStats> = {}
 
-    console.log(`Running scenario ${scenario}`)
+    if (!jsonOutput) {
+      console.log(`Running scenario ${scenario}`)
+    }
 
     for (let version of versions) {
-      console.log(`  React-Redux version: ${version}`)
+      if (!jsonOutput) {
+        console.log(`  React-Redux version: ${version}`)
+      }
+
       const browser = await playwright.chromium.launch({
         headless,
       })
@@ -191,22 +472,38 @@ async function runBenchmarks({
       const folderPath = path.join(distFolder, version, scenario)
 
       if (!fs.existsSync(folderPath)) {
-        console.log(
-          `Scenario ${scenario} does not exist for version ${version}, skipping`
-        )
+        if (!jsonOutput) {
+          console.log(
+            `Scenario ${scenario} does not exist for version ${version}, skipping`
+          )
+        }
         continue
       }
 
+      const bundlePath = enableProfile
+        ? path.join(folderPath, 'index.js')
+        : undefined
+
       const URL = `http://localhost:9999/${version}/${scenario}`
       try {
-        console.log(`    Running benchmark... (${length} seconds)`)
+        if (!jsonOutput) {
+          console.log(`    Running benchmark... (${length} seconds)`)
+        }
         const results = await capturePageStats(
           browser,
           URL,
-          length * 1000
+          length * 1000,
+          enableProfile
         )
 
-        versionPerfEntries[version] = calculateBenchmarkStats(results)
+        if (saveProfiles && results.cpuProfile) {
+          saveCpuProfile(results.cpuProfile, scenario, version)
+        }
+
+        versionPerfEntries[version] = calculateBenchmarkStats(
+          results,
+          bundlePath
+        )
       } catch (e) {
         console.error(e)
         process.exit(-1)
@@ -214,7 +511,16 @@ async function runBenchmarks({
         await browser.close()
       }
     }
-    printBenchmarkResults(scenario, versionPerfEntries)
+
+    if (!jsonOutput) {
+      printBenchmarkResults(scenario, versionPerfEntries, enableProfile)
+    }
+
+    allResults[scenario] = versionPerfEntries
+  }
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(allResults, null, 2))
   }
 
   server.close()

--- a/runBenchmarks.ts
+++ b/runBenchmarks.ts
@@ -348,68 +348,76 @@ function printBenchmarkResults(
   versionPerfEntries: Record<string, BenchmarkStats>,
   showProfile: boolean
 ) {
-  console.log(`\nResults for benchmark ${benchmark}:`)
+  console.log(`\n${chalk.bold.underline(benchmark)}`)
+  console.log(chalk.dim('  All times in ms'))
 
-  const head = [
-    'Version',
-    'Script\n(ms)',
-    'Task\n(ms)',
-    'Layout\n(ms)',
-    'Style\n(ms)',
-    'Mount\n(ms)',
-    'Avg Upd\n(ms)',
-    'p95 Upd\n(ms)',
-    'Renders',
-    'Dispatches\n(avg ms)',
-  ]
+  const versions = Object.keys(versionPerfEntries).sort()
+  const colAligns = ['left', ...Array(10).fill('right')] as (
+    | 'left'
+    | 'right'
+  )[]
 
-  if (showProfile) {
-    head.push(
-      'react-dom\n(ms)',
-      'react\n(ms)',
-      'react-redux\n(ms)',
-      'redux/tk\n(ms)',
-      'app\n(ms)'
-    )
+  // CDP table
+  const cdpTable: any = new Table({
+    head: ['Version', 'Script', 'Task', 'Layout', 'Wall'],
+    style: { head: ['red'] },
+    colAligns,
+  })
+  for (const version of versions) {
+    const s = versionPerfEntries[version]
+    cdpTable.push([
+      version,
+      s.cdp.scriptDuration.toFixed(0),
+      s.cdp.taskDuration.toFixed(0),
+      s.cdp.layoutDuration.toFixed(0),
+      s.wallTime.toFixed(0),
+    ])
   }
+  console.log(cdpTable.toString())
 
-  const table: any = new Table({ head })
+  // React table
+  const reactTable: any = new Table({
+    head: ['Version', 'Mount', 'Avg Upd', 'p95 Upd', 'Renders', 'Dispatches (avg)'],
+    style: { head: ['red'] },
+    colAligns,
+  })
+  for (const version of versions) {
+    const s = versionPerfEntries[version]
+    reactTable.push([
+      version,
+      s.react.mountTime?.toFixed(1) ?? 'N/A',
+      s.react.avgUpdateTime?.toFixed(1) ?? 'N/A',
+      s.react.p95UpdateTime?.toFixed(1) ?? 'N/A',
+      s.react.renderCount,
+      `${s.dispatch.count} (${s.dispatch.avgTime.toFixed(2)})`,
+    ])
+  }
+  console.log(reactTable.toString())
 
-  Object.keys(versionPerfEntries)
-    .sort()
-    .forEach((version) => {
-      const stats = versionPerfEntries[version]
-
-      const row: (string | number)[] = [
-        version,
-        stats.cdp.scriptDuration.toFixed(0),
-        stats.cdp.taskDuration.toFixed(0),
-        stats.cdp.layoutDuration.toFixed(0),
-        stats.cdp.styleDuration.toFixed(0),
-        stats.react.mountTime?.toFixed(1) ?? 'N/A',
-        stats.react.avgUpdateTime?.toFixed(1) ?? 'N/A',
-        stats.react.p95UpdateTime?.toFixed(1) ?? 'N/A',
-        stats.react.renderCount,
-        `${stats.dispatch.count} (${stats.dispatch.avgTime.toFixed(2)})`,
-      ]
-
-      if (showProfile && stats.moduleBreakdown) {
-        const mb = stats.moduleBreakdown
-        row.push(
+  // Profile table (only when --profile)
+  if (showProfile) {
+    const profileTable: any = new Table({
+      head: ['Version', 'react-dom', 'react', 'react-redux', 'redux/tk', 'app'],
+      style: { head: ['red'] },
+      colAligns,
+    })
+    for (const version of versions) {
+      const mb = versionPerfEntries[version].moduleBreakdown
+      if (mb) {
+        profileTable.push([
+          version,
           mb['react-dom'].toFixed(0),
           mb.react.toFixed(0),
           mb['react-redux'].toFixed(0),
           mb['redux/toolkit'].toFixed(0),
-          mb.app.toFixed(0)
-        )
-      } else if (showProfile) {
-        row.push('N/A', 'N/A', 'N/A', 'N/A', 'N/A')
+          mb.app.toFixed(0),
+        ])
+      } else {
+        profileTable.push([version, 'N/A', 'N/A', 'N/A', 'N/A', 'N/A'])
       }
-
-      table.push(row)
-    })
-
-  console.log(table.toString())
+    }
+    console.log(profileTable.toString())
+  }
 }
 
 function saveCpuProfile(

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -2,8 +2,11 @@ import { build, type Plugin } from 'vite'
 import path from 'path'
 import fs from 'fs-extra'
 import glob from 'glob'
+import { instrumentationPlugin } from './plugins/instrumentationPlugin'
 
 const pkg = require(path.join(process.cwd(), 'package.json'))
+
+const enableInstrumentation = process.argv.includes('--instrument')
 
 const readFolderNames = (searchDir: string) => {
   return glob.sync('*/', { cwd: searchDir }).map((s) => s.replace('/', ''))
@@ -29,17 +32,61 @@ async function bundle(options: BuildOptions) {
   const entryPoint = path.join('src/scenarios', scenarioName, 'index.tsx')
 
   const reactReduxPackageVersion = `react-redux-${reactReduxVersion}`
-  const resolvedReactReduxPath = require.resolve(reactReduxPackageVersion)
+  const reactReduxPkgDir = path.dirname(
+    require.resolve(`${reactReduxPackageVersion}/package.json`)
+  )
+  const reactReduxPkg = require(
+    `${reactReduxPackageVersion}/package.json`
+  )
+  // Prefer ESM entry from exports, fall back to CJS
+  const reactReduxEntry = reactReduxPkg.exports?.['.']?.import
+    ? path.join(reactReduxPkgDir, reactReduxPkg.exports['.'].import)
+    : require.resolve(reactReduxPackageVersion)
   const reactDomProfilingPath = require.resolve('react-dom/profiling')
 
-  // Redirect react-dom/client imports to react-dom/profiling for React Profiler support.
-  // Must be a plugin because Vite's resolve.alias doesn't override package.json exports.
+  // Use resolveId hooks instead of resolve.alias to ensure exact matching.
+  // resolve.alias does prefix matching which breaks with pnpm symlinks
+  // (e.g. node_modules/react-redux → yalc version overrides the alias).
   const reactDomProfilingPlugin: Plugin = {
     name: 'react-dom-profiling',
     enforce: 'pre',
     resolveId(source) {
       if (source === 'react-dom/client') {
         return reactDomProfilingPath
+      }
+    },
+  }
+
+  const reactReduxResolvePlugin: Plugin = {
+    name: 'react-redux-version-resolve',
+    enforce: 'pre',
+    resolveId(source) {
+      if (source === 'react-redux') {
+        return reactReduxEntry
+      }
+    },
+  }
+
+  // Fix @babel/runtime CJS interop for react-redux 8.1.1.
+  // @babel/runtime's package.json exports map `./helpers/*` with an `import`
+  // condition pointing to `./helpers/esm/*`. Vite resolves with ESM conditions,
+  // so CJS `require("@babel/runtime/helpers/interopRequireDefault")` gets the
+  // ESM version. Vite then wraps it in __toCommonJS which returns a module
+  // object instead of the function itself, crashing the CJS consumer.
+  // Force CJS resolution for these helpers.
+  const babelRuntimeCjsFixPlugin: Plugin = {
+    name: 'babel-runtime-cjs-fix',
+    enforce: 'pre',
+    resolveId(source) {
+      if (source.startsWith('@babel/runtime/helpers/') && !source.includes('/esm/')) {
+        // Resolve to the CJS file directly, bypassing the exports map
+        const helperName = source.replace('@babel/runtime/helpers/', '')
+        try {
+          const cjsPath = require.resolve(`@babel/runtime/helpers/${helperName}`)
+          return cjsPath
+        } catch {
+          return undefined
+        }
       }
     },
   }
@@ -53,12 +100,12 @@ async function bundle(options: BuildOptions) {
       'process.env.NAME': JSON.stringify(scenarioName),
       'process.env.RR_VERSION': JSON.stringify(reactReduxVersion),
     },
-    resolve: {
-      alias: {
-        'react-redux': resolvedReactReduxPath,
-      },
-    },
-    plugins: [reactDomProfilingPlugin],
+    plugins: [
+      reactDomProfilingPlugin,
+      reactReduxResolvePlugin,
+      babelRuntimeCjsFixPlugin,
+      ...(enableInstrumentation ? [instrumentationPlugin()] : []),
+    ],
     build: {
       outDir: outputFolder,
       emptyOutDir: true,

--- a/scripts/plugins/instrumentationPlugin.ts
+++ b/scripts/plugins/instrumentationPlugin.ts
@@ -1,0 +1,78 @@
+import type { Plugin } from 'vite'
+import { transformReduxDispatch } from '../transforms/reduxTransform'
+import { transformUseSyncExternalStoreWithSelector } from '../transforms/usesTransform'
+import { transformSignalProvider, transformSignalSelector } from '../transforms/reactReduxSignalTransform'
+import { INST_INIT_CODE } from '../../src/common/instrumentation'
+
+/**
+ * Vite plugin that instruments library source code at build time.
+ * Inserts performance.now() timing accumulators into Redux dispatch,
+ * uSES memoizedSelector, and signal experiment hooks.
+ *
+ * Activated by --instrument flag. Module ID matching in the transform hook
+ * identifies which library is being processed.
+ */
+export function instrumentationPlugin(): Plugin {
+  let initInjected = false
+
+  return {
+    name: 'benchmark-instrumentation',
+    enforce: 'pre',
+
+    transform(code, id) {
+      // Normalize path separators for matching
+      const normalizedId = id.replace(/\\/g, '/')
+
+      // Redux dispatch — redux.mjs (ESM)
+      if (normalizedId.includes('/redux/dist/redux.mjs')) {
+        let result = code
+        // Inject accumulator init code at the top of the Redux module (first to load)
+        if (!initInjected) {
+          result = INST_INIT_CODE + '\n' + result
+          initInjected = true
+        }
+        const transformed = transformReduxDispatch(result)
+        if (transformed) {
+          return { code: transformed, map: null }
+        }
+      }
+
+      // uSES production CJS — use-sync-external-store-with-selector.production.js
+      if (normalizedId.includes('use-sync-external-store-with-selector.production')) {
+        let result = code
+        if (!initInjected) {
+          result = INST_INIT_CODE + '\n' + result
+          initInjected = true
+        }
+        const transformed = transformUseSyncExternalStoreWithSelector(result)
+        if (transformed) {
+          return { code: transformed, map: null }
+        }
+      }
+
+      // Signal experiment — the .yalc react-redux resolves through pnpm as
+      // react-redux@file+.yalc+reac.../node_modules/react-redux/dist/react-redux.mjs
+      // Match any react-redux.mjs that comes from a file: protocol link (the .yalc version)
+      if (normalizedId.includes('/react-redux/dist/react-redux.mjs') && normalizedId.includes('file+.yalc')) {
+        let result = code
+        if (!initInjected) {
+          result = INST_INIT_CODE + '\n' + result
+          initInjected = true
+        }
+        const providerTransformed = transformSignalProvider(result)
+        if (providerTransformed) {
+          result = providerTransformed
+        }
+        const selectorTransformed = transformSignalSelector(result)
+        if (selectorTransformed) {
+          result = selectorTransformed
+        }
+        if (result !== code) {
+          return { code: result, map: null }
+        }
+      }
+
+      return null
+    },
+  }
+}

--- a/scripts/test-transforms.ts
+++ b/scripts/test-transforms.ts
@@ -1,0 +1,143 @@
+import fs from 'fs'
+import path from 'path'
+import { transformReduxDispatch } from './transforms/reduxTransform'
+import { transformUseSyncExternalStoreWithSelector } from './transforms/usesTransform'
+import { transformSignalProvider, transformSignalSelector } from './transforms/reactReduxSignalTransform'
+
+function testRedux() {
+  console.log('\n=== Testing Redux Transform ===')
+  const code = fs.readFileSync(
+    path.resolve('node_modules/.pnpm/redux@5.0.1/node_modules/redux/dist/redux.mjs'),
+    'utf-8'
+  )
+  const result = transformReduxDispatch(code)
+  if (!result) {
+    console.log('FAILED: returned null')
+    return
+  }
+
+  // Check reducer timing is present
+  const hasReducerTiming = result.includes('globalThis.__benchInst.reducerTime')
+  const hasReducerCount = result.includes('globalThis.__benchInst.reducerCount')
+  const hasNotifyTiming = result.includes('globalThis.__benchInst.notifyTime')
+  const hasCallbackCount = result.includes('globalThis.__benchInst.callbackCount')
+
+  console.log(`  reducerTime: ${hasReducerTiming ? 'OK' : 'MISSING'}`)
+  console.log(`  reducerCount: ${hasReducerCount ? 'OK' : 'MISSING'}`)
+  console.log(`  notifyTime: ${hasNotifyTiming ? 'OK' : 'MISSING'}`)
+  console.log(`  callbackCount: ${hasCallbackCount ? 'OK' : 'MISSING'}`)
+
+  // Show the instrumented dispatch section
+  const dispatchIdx = result.indexOf('function dispatch(action)')
+  if (dispatchIdx !== -1) {
+    const section = result.slice(dispatchIdx, dispatchIdx + 800)
+    const returnIdx = section.indexOf('return action')
+    if (returnIdx !== -1) {
+      console.log('\n  Instrumented dispatch body:')
+      console.log(section.slice(0, returnIdx + 20).split('\n').map(l => '    ' + l).join('\n'))
+    }
+  }
+
+  console.log(`  RESULT: ${hasReducerTiming && hasNotifyTiming ? 'PASS' : 'FAIL'}`)
+}
+
+function testUses() {
+  console.log('\n=== Testing uSES Transform ===')
+  const code = fs.readFileSync(
+    path.resolve('node_modules/.pnpm/use-sync-external-store@1.6.0_react@19.2.6/node_modules/use-sync-external-store/cjs/use-sync-external-store-with-selector.production.js'),
+    'utf-8'
+  )
+  const result = transformUseSyncExternalStoreWithSelector(code)
+  if (!result) {
+    console.log('FAILED: returned null')
+    return
+  }
+
+  const hasSelectorTiming = result.includes('globalThis.__benchInst.selectorTime')
+  const hasSelectorCount = result.includes('globalThis.__benchInst.selectorCount')
+  const hasEqualityTiming = result.includes('globalThis.__benchInst.equalityCheckTime')
+  const hasEqualityCount = result.includes('globalThis.__benchInst.equalityCheckCount')
+
+  console.log(`  selectorTime: ${hasSelectorTiming ? 'OK' : 'MISSING'}`)
+  console.log(`  selectorCount: ${hasSelectorCount ? 'OK' : 'MISSING'}`)
+  console.log(`  equalityCheckTime: ${hasEqualityTiming ? 'OK' : 'MISSING'}`)
+  console.log(`  equalityCheckCount: ${hasEqualityCount ? 'OK' : 'MISSING'}`)
+
+  // Show the memoizedSelector function
+  const memoIdx = result.indexOf('function memoizedSelector')
+  if (memoIdx !== -1) {
+    const endIdx = result.indexOf('var hasMemo', memoIdx)
+    if (endIdx !== -1) {
+      console.log('\n  Instrumented memoizedSelector:')
+      console.log(result.slice(memoIdx, endIdx).split('\n').map(l => '    ' + l).join('\n'))
+    }
+  }
+
+  console.log(`  RESULT: ${hasSelectorTiming && hasEqualityTiming ? 'PASS' : 'FAIL'}`)
+}
+
+function testSignalProvider() {
+  console.log('\n=== Testing Signal Provider Transform ===')
+  const code = fs.readFileSync(
+    path.resolve('.yalc/react-redux/dist/react-redux.mjs'),
+    'utf-8'
+  )
+  const result = transformSignalProvider(code)
+  if (!result) {
+    console.log('FAILED: returned null')
+    return
+  }
+
+  const hasReconcileTime = result.includes('globalThis.__benchInst.reconcileTime')
+  const hasReconcileCount = result.includes('globalThis.__benchInst.reconcileCount')
+
+  console.log(`  reconcileTime: ${hasReconcileTime ? 'OK' : 'MISSING'}`)
+  console.log(`  reconcileCount: ${hasReconcileCount ? 'OK' : 'MISSING'}`)
+
+  // Show the store.subscribe callback
+  const subIdx = result.indexOf('store.subscribe(')
+  if (subIdx !== -1) {
+    const section = result.slice(subIdx, subIdx + 500)
+    const endIdx = section.indexOf('});')
+    if (endIdx !== -1) {
+      console.log('\n  Instrumented store.subscribe:')
+      console.log(section.slice(0, endIdx + 3).split('\n').map(l => '    ' + l).join('\n'))
+    }
+  }
+
+  console.log(`  RESULT: ${hasReconcileTime && hasReconcileCount ? 'PASS' : 'FAIL'}`)
+}
+
+function testSignalSelector() {
+  console.log('\n=== Testing Signal Selector Transform ===')
+  const code = fs.readFileSync(
+    path.resolve('.yalc/react-redux/dist/react-redux.mjs'),
+    'utf-8'
+  )
+  const result = transformSignalSelector(code)
+  if (!result) {
+    console.log('FAILED: returned null')
+    return
+  }
+
+  const hasSelectorTime = result.includes('globalThis.__benchInst.signalSelectorTime')
+  const hasSelectorCount = result.includes('globalThis.__benchInst.signalSelectorCount')
+
+  console.log(`  signalSelectorTime: ${hasSelectorTime ? 'OK' : 'MISSING'}`)
+  console.log(`  signalSelectorCount: ${hasSelectorCount ? 'OK' : 'MISSING'}`)
+
+  // Show the createMemo callback
+  const memoIdx = result.indexOf('const memo = createMemo')
+  if (memoIdx !== -1) {
+    const section = result.slice(memoIdx, memoIdx + 600)
+    console.log('\n  Instrumented createMemo:')
+    console.log(section.split('\n').slice(0, 15).map(l => '    ' + l).join('\n'))
+  }
+
+  console.log(`  RESULT: ${hasSelectorTime && hasSelectorCount ? 'PASS' : 'FAIL'}`)
+}
+
+testRedux()
+testUses()
+testSignalProvider()
+testSignalSelector()

--- a/scripts/transforms/reactReduxSignalTransform.ts
+++ b/scripts/transforms/reactReduxSignalTransform.ts
@@ -1,0 +1,260 @@
+import { parse, Lang } from '@ast-grep/napi'
+
+/**
+ * Instruments SignalProvider's store subscription callback to time reconcile + flush.
+ *
+ * Target pattern in .yalc/react-redux/dist/react-redux.mjs:
+ *   const storeUnsubscribe = store.subscribe(() => {
+ *     const newState = store.getState();
+ *     setStore(reconcile(newState, keyFn));
+ *     flush();
+ *   });
+ *
+ * We wrap the two lines (setStore + flush) with timing.
+ */
+export function transformSignalProvider(code: string): string | null {
+  const root = parse(Lang.JavaScript, code).root()
+
+  // Find: setStore(reconcile(newState, keyFn))
+  const reconcileCall = root.find({
+    rule: {
+      pattern: 'setStore(reconcile($_, $_))',
+    },
+  })
+
+  if (!reconcileCall) {
+    console.warn('[instrumentation] Could not find setStore(reconcile(...)) in signal provider')
+    return null
+  }
+
+  // Find: flush() — the one immediately after setStore
+  // We want the flush() call that's in the same callback as setStore(reconcile(...))
+  const flushCalls = root.findAll({
+    rule: {
+      pattern: 'flush()',
+    },
+  })
+
+  // Find the flush() that's nearest after the reconcile call
+  const reconcileEnd = reconcileCall.range().end.index
+  let targetFlush = null
+  for (const fc of flushCalls) {
+    if (fc.range().start.index > reconcileEnd) {
+      targetFlush = fc
+      break
+    }
+  }
+
+  if (!targetFlush) {
+    console.warn('[instrumentation] Could not find flush() after setStore(reconcile(...))')
+    return null
+  }
+
+  // Get the expression_statement for setStore (we want to insert before it)
+  const setStoreStmt = reconcileCall.parent()
+  if (!setStoreStmt) {
+    console.warn('[instrumentation] Could not find setStore parent statement')
+    return null
+  }
+
+  // Get the expression_statement for flush() (we want to insert after it)
+  const flushStmt = targetFlush.parent()
+  if (!flushStmt) {
+    console.warn('[instrumentation] Could not find flush parent statement')
+    return null
+  }
+
+  const beforeStart = setStoreStmt.range().start.index
+  let afterEnd = flushStmt.range().end.index
+  // Include trailing semicolon
+  if (code[afterEnd] === ';') afterEnd++
+
+  // Insert timing around the setStore + flush block
+  const before = 'const __tr0 = performance.now(); '
+  const after = ' const __tr1 = performance.now(); globalThis.__benchInst.reconcileTime += __tr1 - __tr0; globalThis.__benchInst.reconcileCount++;'
+
+  let result = code
+  // Insert after first (higher offset)
+  result = result.slice(0, afterEnd) + after + result.slice(afterEnd)
+  // Insert before (lower offset, still valid)
+  result = result.slice(0, beforeStart) + before + result.slice(beforeStart)
+
+  return result
+}
+
+/**
+ * Instruments useSignalSelector's createMemo callback to time signal selector execution.
+ *
+ * Target pattern in .yalc/react-redux/dist/react-redux.mjs:
+ *   const memo = createMemo(
+ *     () => {
+ *       track();
+ *       const result = selectorRef.current(solidStore);
+ *       deepRead(result);
+ *       return snapshot(result);
+ *     },
+ *     ...
+ *   );
+ *
+ * We wrap the body of the arrow function passed to createMemo.
+ */
+export function transformSignalSelector(code: string): string | null {
+  const root = parse(Lang.JavaScript, code).root()
+
+  // Find: selectorRef.current(solidStore)
+  // This is the unique pattern inside the createMemo callback
+  const selectorCall = root.find({
+    rule: {
+      pattern: 'selectorRef.current(solidStore)',
+    },
+  })
+
+  if (!selectorCall) {
+    console.warn('[instrumentation] Could not find selectorRef.current(solidStore) in signal selector')
+    return null
+  }
+
+  // Navigate up to find the arrow function body that contains this call.
+  // We want to instrument: track() through return snapshot(result)
+  //
+  // Find track() call that's in the same block
+  const trackCalls = root.findAll({
+    rule: {
+      pattern: 'track()',
+    },
+  })
+
+  // Find the track() call nearest before selectorRef.current(solidStore)
+  const selectorStart = selectorCall.range().start.index
+  let targetTrack = null
+  for (const tc of trackCalls) {
+    if (tc.range().start.index < selectorStart) {
+      targetTrack = tc
+    }
+  }
+
+  if (!targetTrack) {
+    console.warn('[instrumentation] Could not find track() before selectorRef.current(solidStore)')
+    return null
+  }
+
+  // Find `return snapshot(result)` after the selector call
+  const snapshotReturns = root.findAll({
+    rule: {
+      pattern: 'return snapshot($_)',
+    },
+  })
+
+  let targetReturn = null
+  for (const sr of snapshotReturns) {
+    if (sr.range().start.index > selectorStart) {
+      targetReturn = sr
+      break
+    }
+  }
+
+  if (!targetReturn) {
+    console.warn('[instrumentation] Could not find return snapshot(result) after selector call')
+    return null
+  }
+
+  // Get the track() statement start
+  const trackStmt = targetTrack.parent()
+  if (!trackStmt) {
+    console.warn('[instrumentation] Could not find track() parent statement')
+    return null
+  }
+
+  // Get the return statement end
+  let returnEnd = targetReturn.range().end.index
+  if (code[returnEnd] === ';') returnEnd++
+
+  const trackStart = trackStmt.range().start.index
+
+  // Insert timing: before track() and after return snapshot(result)
+  // Since `return` is involved, we need to capture the return value
+  // Strategy: wrap in a block that times and then returns
+  //
+  // Original:
+  //   track();
+  //   const result = selectorRef.current(solidStore);
+  //   deepRead(result);
+  //   return snapshot(result);
+  //
+  // Instrumented:
+  //   const __tss0 = performance.now();
+  //   track();
+  //   const result = selectorRef.current(solidStore);
+  //   deepRead(result);
+  //   const __tssR = snapshot(result);
+  //   globalThis.__benchInst.signalSelectorTime += performance.now() - __tss0;
+  //   globalThis.__benchInst.signalSelectorCount++;
+  //   return __tssR;
+  //
+  // But this requires rewriting the return statement. Let's do a simpler approach:
+  // Just time from track() to after return, wrapping the whole block minus the return.
+
+  // Actually, simplest approach: insert timing start before track(),
+  // and timing end after the `return snapshot(result);` — but that won't execute
+  // because `return` exits. So we need to transform the return.
+
+  // Let's use a different strategy: wrap the entire memo callback body.
+  // Find the return statement and replace it.
+
+  // Find `snapshot(result)` in the return
+  const snapshotCall = targetReturn.find({
+    rule: {
+      pattern: 'snapshot($_)',
+    },
+  })
+
+  if (!snapshotCall) {
+    console.warn('[instrumentation] Could not find snapshot() in return statement')
+    return null
+  }
+
+  // Strategy: 
+  // 1. Insert `const __tss0 = performance.now();` before track()
+  // 2. Replace `return snapshot(result);` with
+  //    `const __tssR = snapshot(result); globalThis.__benchInst.signalSelectorTime += performance.now() - __tss0; globalThis.__benchInst.signalSelectorCount++; return __tssR;`
+
+  const returnStart = targetReturn.range().start.index
+
+  interface Splice {
+    offset: number
+    deleteCount: number
+    insert: string
+  }
+  const splices: Splice[] = []
+
+  // Insert timing start before track()
+  splices.push({
+    offset: trackStart,
+    deleteCount: 0,
+    insert: 'const __tss0 = performance.now(); ',
+  })
+
+  // Replace the entire return statement
+  const returnText = code.slice(returnStart, returnEnd)
+  // Extract the snapshot call text from the return
+  const snapshotText = code.slice(snapshotCall.range().start.index, snapshotCall.range().end.index)
+
+  splices.push({
+    offset: returnStart,
+    deleteCount: returnEnd - returnStart,
+    insert: `const __tssR = ${snapshotText}; globalThis.__benchInst.signalSelectorTime += performance.now() - __tss0; globalThis.__benchInst.signalSelectorCount++; return __tssR;`,
+  })
+
+  // Apply in reverse offset order
+  splices.sort((a, b) => b.offset - a.offset)
+
+  let result = code
+  for (const splice of splices) {
+    result =
+      result.slice(0, splice.offset) +
+      splice.insert +
+      result.slice(splice.offset + splice.deleteCount)
+  }
+
+  return result
+}

--- a/scripts/transforms/reduxTransform.ts
+++ b/scripts/transforms/reduxTransform.ts
@@ -1,0 +1,112 @@
+import { parse, Lang } from '@ast-grep/napi'
+
+/**
+ * Instruments Redux's dispatch() function to time:
+ * 1. Reducer execution: currentReducer(currentState, action)
+ * 2. Listener notification: listeners.forEach(...)
+ *
+ * Target source pattern in redux.mjs:
+ *   try {
+ *     isDispatching = true;
+ *     currentState = currentReducer(currentState, action);
+ *   } finally {
+ *     isDispatching = false;
+ *   }
+ *   const listeners = currentListeners = nextListeners;
+ *   listeners.forEach((listener) => { listener(); });
+ */
+export function transformReduxDispatch(code: string): string | null {
+  const root = parse(Lang.JavaScript, code).root()
+
+  // Find: currentState = currentReducer(currentState, action)
+  // This is an assignment where the RHS is a call to currentReducer
+  const reducerAssignment = root.find({
+    rule: {
+      pattern: 'currentState = currentReducer(currentState, action)',
+    },
+  })
+
+  if (!reducerAssignment) {
+    console.warn('[instrumentation] Could not find currentReducer call in redux.mjs')
+    return null
+  }
+
+  // Find: listeners.forEach(...)
+  // The forEach call on the listeners Map
+  const forEachCall = root.find({
+    rule: {
+      pattern: 'listeners.forEach($$$)',
+      inside: {
+        kind: 'expression_statement',
+        stopBy: 'end',
+      },
+    },
+  })
+
+  if (!forEachCall) {
+    console.warn('[instrumentation] Could not find listeners.forEach in redux.mjs')
+    return null
+  }
+
+  // Get byte ranges for splicing
+  // We need the expression_statement containing forEach, not just the call
+  const forEachStatement = forEachCall.parent()
+  if (!forEachStatement) {
+    console.warn('[instrumentation] Could not find forEach parent statement')
+    return null
+  }
+
+  // Build the instrumented code by splicing
+  // We work backwards (higher offsets first) to keep earlier offsets valid
+
+  interface Splice {
+    offset: number
+    insert: string
+  }
+  const splices: Splice[] = []
+
+  // --- Reducer instrumentation ---
+  // Wrap: currentState = currentReducer(currentState, action)
+  // Into: { const __t0 = performance.now(); currentState = currentReducer(currentState, action); const __t1 = performance.now(); globalThis.__benchInst.reducerTime += __t1 - __t0; globalThis.__benchInst.reducerCount++; }
+  const reducerStart = reducerAssignment.range().start.index
+  const reducerEnd = reducerAssignment.range().end.index
+
+  // Find the semicolon after the assignment (it's inside a try block)
+  // The assignment is `currentState = currentReducer(currentState, action)`
+  // In the source it's followed by a semicolon
+  let reducerStmtEnd = reducerEnd
+  if (code[reducerStmtEnd] === ';') reducerStmtEnd++
+
+  splices.push({
+    offset: reducerStart,
+    insert: 'const __t0 = performance.now(); ',
+  })
+  splices.push({
+    offset: reducerStmtEnd,
+    insert: ' const __t1 = performance.now(); globalThis.__benchInst.reducerTime += __t1 - __t0; globalThis.__benchInst.reducerCount++;',
+  })
+
+  // --- Listener notification instrumentation ---
+  // Wrap the entire forEach statement
+  const forEachStart = forEachStatement.range().start.index
+  const forEachEnd = forEachStatement.range().end.index
+
+  splices.push({
+    offset: forEachStart,
+    insert: 'const __tn0 = performance.now(); ',
+  })
+  splices.push({
+    offset: forEachEnd,
+    insert: ' const __tn1 = performance.now(); globalThis.__benchInst.notifyTime += __tn1 - __tn0; globalThis.__benchInst.callbackCount += listeners.size;',
+  })
+
+  // Apply splices in reverse offset order
+  splices.sort((a, b) => b.offset - a.offset)
+
+  let result = code
+  for (const splice of splices) {
+    result = result.slice(0, splice.offset) + splice.insert + result.slice(splice.offset)
+  }
+
+  return result
+}

--- a/scripts/transforms/usesTransform.ts
+++ b/scripts/transforms/usesTransform.ts
@@ -1,0 +1,111 @@
+import { parse, Lang } from '@ast-grep/napi'
+
+/**
+ * Instruments useSyncExternalStoreWithSelector's memoizedSelector function.
+ *
+ * Target: production CJS (semi-minified, but variable names preserved).
+ * The memoizedSelector function has two paths:
+ *
+ * 1. First call (!hasMemo):
+ *    - selector(nextSnapshot) → selectorTime
+ *    - isEqual(currentSelection, nextSnapshot) → equalityCheckTime
+ *
+ * 2. Subsequent calls:
+ *    - objectIs(memoizedSnapshot, nextSnapshot) → short circuit (no cost)
+ *    - selector(nextSnapshot) → selectorTime
+ *    - isEqual(currentSelection, nextSelection) → equalityCheckTime
+ *
+ * We wrap every selector() call and every isEqual() call.
+ */
+export function transformUseSyncExternalStoreWithSelector(code: string): string | null {
+  const root = parse(Lang.JavaScript, code).root()
+
+  // Strategy: find all `selector(nextSnapshot)` calls and `isEqual(...)` calls
+  // within the memoizedSelector function body.
+  //
+  // Since this is CJS with a specific structure, we use pattern matching.
+  // The function has these exact call patterns:
+  //   selector(nextSnapshot)     — called twice (first-run and cache-miss paths)
+  //   isEqual(currentSelection, nextSnapshot)  — first-run path
+  //   isEqual(currentSelection, nextSelection) — cache-miss path
+
+  // Find all selector(nextSnapshot) calls
+  const selectorCalls = root.findAll({
+    rule: {
+      pattern: 'selector(nextSnapshot)',
+    },
+  })
+
+  if (selectorCalls.length === 0) {
+    console.warn('[instrumentation] Could not find selector(nextSnapshot) in uSES')
+    return null
+  }
+
+  // Find all isEqual calls (two-argument calls to isEqual)
+  const isEqualCalls = root.findAll({
+    rule: {
+      pattern: 'isEqual($_, $_)',
+    },
+  })
+
+  // Build splice list
+  interface Splice {
+    offset: number
+    deleteCount: number
+    insert: string
+  }
+  const splices: Splice[] = []
+
+  // Wrap each selector(nextSnapshot) call:
+  //   selector(nextSnapshot)
+  // becomes:
+  //   (globalThis.__benchInst.selectorCount++, (() => { const __ts0 = performance.now(); const __tsR = selector(nextSnapshot); globalThis.__benchInst.selectorTime += performance.now() - __ts0; return __tsR; })())
+  //
+  // But this is complex as an expression replacement. Simpler: since these are
+  // used in assignments like `nextSnapshot = selector(nextSnapshot)`, we can
+  // wrap the call expression inline.
+  //
+  // Actually, the cleanest approach: replace `selector(nextSnapshot)` with a
+  // timing wrapper IIFE.
+
+  for (const call of selectorCalls) {
+    const start = call.range().start.index
+    const end = call.range().end.index
+    const original = code.slice(start, end)
+
+    splices.push({
+      offset: start,
+      deleteCount: end - start,
+      insert: `(globalThis.__benchInst.selectorCount++, (() => { const __ts = performance.now(); const __tr = ${original}; globalThis.__benchInst.selectorTime += performance.now() - __ts; return __tr; })())`,
+    })
+  }
+
+  for (const call of isEqualCalls) {
+    const start = call.range().start.index
+    const end = call.range().end.index
+    const original = code.slice(start, end)
+
+    splices.push({
+      offset: start,
+      deleteCount: end - start,
+      insert: `(globalThis.__benchInst.equalityCheckCount++, (() => { const __te = performance.now(); const __tr = ${original}; globalThis.__benchInst.equalityCheckTime += performance.now() - __te; return __tr; })())`,
+    })
+  }
+
+  if (splices.length === 0) {
+    return null
+  }
+
+  // Apply splices in reverse offset order
+  splices.sort((a, b) => b.offset - a.offset)
+
+  let result = code
+  for (const splice of splices) {
+    result =
+      result.slice(0, splice.offset) +
+      splice.insert +
+      result.slice(splice.offset + splice.deleteCount)
+  }
+
+  return result
+}

--- a/src/common/instrumentation.ts
+++ b/src/common/instrumentation.ts
@@ -1,0 +1,58 @@
+// Instrumentation accumulator — injected at build time by the instrumentation plugin.
+// Uses performance.now() deltas accumulated in numeric counters (not performance.mark()).
+// Matches the pattern established by dispatch-timing.ts.
+
+export interface InstrumentationStats {
+  // Redux dispatch decomposition
+  reducerTime: number
+  reducerCount: number
+  notifyTime: number
+  callbackCount: number
+
+  // uSES selector path (react-redux 9.2.0 standard)
+  selectorTime: number
+  selectorCount: number
+  equalityCheckTime: number
+  equalityCheckCount: number
+
+  // Signal experiment path (react-redux 9.2.0-shallow-checks)
+  reconcileTime: number
+  reconcileCount: number
+  signalSelectorTime: number
+  signalSelectorCount: number
+}
+
+// This code is injected as a preamble string by the instrumentation plugin,
+// NOT imported at runtime. The TypeScript here serves as documentation and
+// type-checking for the shape. The actual injection is a raw JS string
+// in the transform plugin.
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __benchInst: InstrumentationStats
+  interface Window {
+    getInstrumentationStats: () => InstrumentationStats
+  }
+}
+
+export const INST_INIT_CODE = `
+if (typeof globalThis.__benchInst === 'undefined') {
+  globalThis.__benchInst = {
+    reducerTime: 0,
+    reducerCount: 0,
+    notifyTime: 0,
+    callbackCount: 0,
+    selectorTime: 0,
+    selectorCount: 0,
+    equalityCheckTime: 0,
+    equalityCheckCount: 0,
+    reconcileTime: 0,
+    reconcileCount: 0,
+    signalSelectorTime: 0,
+    signalSelectorCount: 0,
+  };
+  window.getInstrumentationStats = function() {
+    return Object.assign({}, globalThis.__benchInst);
+  };
+}
+`.trim()

--- a/utils/server.ts
+++ b/utils/server.ts
@@ -57,12 +57,28 @@ export interface V8ProfileNode {
   children?: number[]
 }
 
+export interface InstrumentationStatsResult {
+  reducerTime: number
+  reducerCount: number
+  notifyTime: number
+  callbackCount: number
+  selectorTime: number
+  selectorCount: number
+  equalityCheckTime: number
+  equalityCheckCount: number
+  reconcileTime: number
+  reconcileCount: number
+  signalSelectorTime: number
+  signalSelectorCount: number
+}
+
 export interface PageStatsResult {
   cdpMetrics: CDPMetricsDelta
   dispatchStats: DispatchStats
   reactTimingEntries: RenderResult[]
   wallTime: number
   cpuProfile?: V8CpuProfile
+  instrumentationStats?: InstrumentationStatsResult
 }
 
 declare global {
@@ -125,7 +141,8 @@ export async function capturePageStats(
   browser: Browser,
   url: string,
   delay = 30000,
-  enableProfiling = false
+  enableProfiling = false,
+  collectInstrumentation = false
 ): Promise<PageStatsResult> {
   const context = await browser.newContext({})
   const page = await context.newPage()
@@ -177,9 +194,20 @@ export async function capturePageStats(
     await cdp.send('Profiler.disable')
   }
 
+  // Collect instrumentation stats if available
+  let instrumentationStats: InstrumentationStatsResult | undefined
+  if (collectInstrumentation) {
+    instrumentationStats = await page.evaluate(() => {
+      if (typeof window.getInstrumentationStats === 'function') {
+        return window.getInstrumentationStats()
+      }
+      return null
+    }) ?? undefined
+  }
+
   await cdp.detach()
   await page.close()
   await context.close()
 
-  return { cdpMetrics, dispatchStats, reactTimingEntries, wallTime, cpuProfile }
+  return { cdpMetrics, dispatchStats, reactTimingEntries, wallTime, cpuProfile, instrumentationStats }
 }

--- a/utils/server.ts
+++ b/utils/server.ts
@@ -35,11 +35,34 @@ export interface CDPMetricsDelta {
   JSHeapUsedSize: number
 }
 
+// V8 CPU profile types (subset of the Chrome DevTools Protocol format)
+export interface V8CpuProfile {
+  nodes: V8ProfileNode[]
+  startTime: number
+  endTime: number
+  samples?: number[]
+  timeDeltas?: number[]
+}
+
+export interface V8ProfileNode {
+  id: number
+  callFrame: {
+    functionName: string
+    scriptId: string
+    url: string
+    lineNumber: number
+    columnNumber: number
+  }
+  hitCount?: number
+  children?: number[]
+}
+
 export interface PageStatsResult {
   cdpMetrics: CDPMetricsDelta
   dispatchStats: DispatchStats
   reactTimingEntries: RenderResult[]
   wallTime: number
+  cpuProfile?: V8CpuProfile
 }
 
 declare global {
@@ -101,7 +124,8 @@ function computeMetricsDelta(
 export async function capturePageStats(
   browser: Browser,
   url: string,
-  delay = 30000
+  delay = 30000,
+  enableProfiling = false
 ): Promise<PageStatsResult> {
   const context = await browser.newContext({})
   const page = await context.newPage()
@@ -109,6 +133,12 @@ export async function capturePageStats(
   // Set up CDP session for Performance metrics
   const cdp = await context.newCDPSession(page)
   await cdp.send('Performance.enable')
+
+  // Optional V8 CPU profiling
+  if (enableProfiling) {
+    await cdp.send('Profiler.enable')
+    await cdp.send('Profiler.start')
+  }
 
   await page.goto(url)
 
@@ -139,9 +169,17 @@ export async function capturePageStats(
     return window.renderResults
   })
 
+  // Stop V8 CPU profiling and collect profile
+  let cpuProfile: V8CpuProfile | undefined
+  if (enableProfiling) {
+    const result = await cdp.send('Profiler.stop')
+    cpuProfile = result.profile as unknown as V8CpuProfile
+    await cdp.send('Profiler.disable')
+  }
+
   await cdp.detach()
   await page.close()
   await context.close()
 
-  return { cdpMetrics, dispatchStats, reactTimingEntries, wallTime }
+  return { cdpMetrics, dispatchStats, reactTimingEntries, wallTime, cpuProfile }
 }


### PR DESCRIPTION
This PR:

- Adds v8 CPU profiling support
- Parses the CPU profile with sourcemap support to determine the cumulative time for each major package (React, Redux, React-Redux, app itself)
- Adds source code level instrumentation to capture details on reducer / notification / selector / callback / signal update timings
- Completely revamps the display so we now have separate tables per scenario, for scripting, React updates, and time-per-package:

<img width="1065" height="749" alt="image" src="https://github.com/user-attachments/assets/7b94579a-6bbb-4d73-b241-a9fead0901b2" />
