### PR TITLE
Add a `price-ticker` scenario (many components, non-memoized per-row selector)

### DIFF
--- a/src/scenarios/price-ticker/App.tsx
+++ b/src/scenarios/price-ticker/App.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+
+import { NUM_INSTRUMENTS } from './constants'
+import type { RootState } from './state'
+
+// A realistic per-row derive for a trading grid: % change vs. open plus a small
+// sparkline summary (min / max / SMA) over the price history. This is the very
+// common "just compute it in the selector" pattern — deliberately NOT a
+// reselect-memoized selector — so it re-runs for every subscriber on every tick.
+//
+// It returns a single primitive signature so React-Redux's equality check can
+// still bail out the rows whose instrument didn't tick, while the work itself
+// runs regardless.
+function selectRowSignature(state: RootState, index: number): number {
+  const inst = state.instruments[index]
+  const h = inst.history
+
+  let min = Infinity
+  let max = -Infinity
+  let sum = 0
+  for (let i = 0; i < h.length; i++) {
+    const v = h[i]
+    if (v < min) min = v
+    if (v > max) max = v
+    sum += v
+  }
+
+  const last = h[h.length - 1]
+  const sma = sum / h.length
+  const changePct = (last - inst.open) / inst.open
+  const range = max - min || 1
+  const sparkPos = (last - min) / range
+
+  return Math.round((sma * 1e4 + changePct * 1e3 + sparkPos * 100) * 100)
+}
+
+function Row({ index }: { index: number }) {
+  const signature = useSelector((state: RootState) =>
+    selectRowSignature(state, index),
+  )
+
+  return <div>{signature}</div>
+}
+
+function App() {
+  return (
+    <div>
+      {Array.from({ length: NUM_INSTRUMENTS }, (_, index) => (
+        <Row key={index} index={index} />
+      ))}
+    </div>
+  )
+}
+
+export default App

--- a/src/scenarios/price-ticker/constants.ts
+++ b/src/scenarios/price-ticker/constants.ts
@@ -1,0 +1,15 @@
+// A trading / forex price board. A watchlist of instruments whose prices tick
+// frequently; every row derives a small indicator (spread, % change, sparkline
+// stats) from its instrument in a plain, non-memoized `useSelector`.
+//
+// The point of interest: only a handful of prices change per tick, but
+// react-redux notifies *every* subscriber on every store update, so all
+// NUM_INSTRUMENTS selectors re-run on each tick — a realistic large-app fan-out.
+
+export const NUM_INSTRUMENTS = 10000
+
+// Prices that change on each tick (the rest are unchanged, but still re-selected).
+export const PRICES_PER_TICK = 30
+
+// Length of the per-instrument price history the sparkline/indicators run over.
+export const HISTORY_LENGTH = 64

--- a/src/scenarios/price-ticker/index.tsx
+++ b/src/scenarios/price-ticker/index.tsx
@@ -1,0 +1,28 @@
+import React, { useLayoutEffect } from 'react'
+import { configureStore } from '@reduxjs/toolkit'
+
+import { renderApp } from '../../common'
+import { dispatchTimingMiddleware } from '../../common/dispatch-timing'
+
+import App from './App'
+import rootReducer, { tick } from './state'
+
+const store = configureStore({
+  reducer: rootReducer,
+  middleware: (gdm) =>
+    gdm({
+      immutabilityCheck: false,
+      serializableCheck: false,
+    }).concat(dispatchTimingMiddleware),
+})
+
+const RootApp = () => {
+  useLayoutEffect(() => {
+    setInterval(() => store.dispatch(tick()), 13)
+  }, [])
+
+  return <App />
+}
+
+// @ts-ignore
+renderApp(RootApp, store)

--- a/src/scenarios/price-ticker/state.ts
+++ b/src/scenarios/price-ticker/state.ts
@@ -1,0 +1,72 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+import { NUM_INSTRUMENTS, PRICES_PER_TICK, HISTORY_LENGTH } from './constants'
+
+export interface Instrument {
+  symbol: string
+  open: number
+  price: number
+  history: number[]
+}
+
+export interface RootState {
+  instruments: Instrument[]
+}
+
+const CCY = ['EUR', 'USD', 'GBP', 'JPY', 'CHF', 'AUD', 'CAD', 'NZD']
+
+function makeSymbol(i: number) {
+  return `${CCY[i % CCY.length]}/${CCY[(i * 7 + 3) % CCY.length]}#${i}`
+}
+
+// Deterministic PRNG so runs are comparable across versions.
+function mulberry32(seed: number) {
+  return () => {
+    seed |= 0
+    seed = (seed + 0x6d2b79f5) | 0
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const rng = mulberry32(0xc0ffee)
+
+const initialInstruments: Instrument[] = Array.from(
+  { length: NUM_INSTRUMENTS },
+  (_, i) => {
+    const base = 0.5 + rng() * 1.5
+    return {
+      symbol: makeSymbol(i),
+      open: base,
+      price: base,
+      history: Array.from({ length: HISTORY_LENGTH }, () => base),
+    }
+  },
+)
+
+// Cheap LCG for choosing which instruments tick, so the reducer stays cheap and
+// the measured dispatch cost is dominated by the subscriber fan-out, not this.
+let tickSeed = 1
+
+const { reducer, actions } = createSlice({
+  name: 'market',
+  initialState: { instruments: initialInstruments } as RootState,
+  reducers: {
+    tick(state) {
+      const n = state.instruments.length
+      for (let k = 0; k < PRICES_PER_TICK; k++) {
+        tickSeed = (tickSeed * 1103515245 + 12345) & 0x7fffffff
+        const inst = state.instruments[tickSeed % n]
+        const drift = (((tickSeed >>> 8) & 0xff) / 255 - 0.5) * 0.004
+        inst.price = Math.max(0.0001, inst.price * (1 + drift))
+        inst.history.push(inst.price)
+        if (inst.history.length > HISTORY_LENGTH) inst.history.shift()
+      }
+    },
+  },
+})
+
+export const { tick } = actions
+
+export default reducer


### PR DESCRIPTION
## What

This adds a `price-ticker` scenario, modelled on a shape the suite doesn't cover yet: a trading / forex price board. A big watchlist of instruments whose prices tick constantly, where every row derives a little indicator — spread, % change vs. open, a sparkline min/max/SMA over recent price history — right inside a plain `useSelector`. Basically the "eh, I'll just compute it in the selector" pattern, un-memoized, at scale.

## Why

The selector-heavy scenarios we already have sit at two other points in the space. `many-components-same-slice` / `many-components-many-slices` have lots of components but trivial `state.x` selectors, so the per-subscriber cost is basically nothing. `derived-selectors` does real derives, but through memoized `createSelector`, so a selector only recomputes when its inputs actually change.

What's missing is the middle: many components each running a non-trivial selector that *isn't* memoized. And that's the case that actually bites, because react-redux notifies every subscriber on every store update. Here only ~30 of 10,000 prices move per tick, but all 10,000 selectors re-run every tick anyway. That `O(subscribers)` fan-out is a real cost in large apps, it's separate from render cost, and nothing in the suite isolates it right now. It's also a handy scenario for anything that touches how subscribers get notified.

## How it's built

10,000 instruments; a deterministic (seeded) subset of 30 ticks each frame via `setInterval(dispatch(tick()), 13)`, so the reducer stays cheap and the cost you measure is the subscriber fan-out, not state churn. Each row's selector reads its instrument's 64-point price history and returns a single primitive signature, so the equality check still bails out the rows whose price didn't move, while the derive work runs for every subscriber regardless. Same shape as the other `many-components-*` scenarios (own slice, dispatch-timing middleware), so it drops straight into the harness — `yarn build` picks it up automatically.

Run it with `yarn start -s price-ticker`.
