### PR TITLE
Show total time blocked inside dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,24 @@ yarn build && yalc publish
 yalc add react-redux && pnpm install
 ```
 
+## Reading the results
+
+### `Blocked` — total time inside `dispatch()`
+
+`Blocked` is the sum of every `dispatch()` call's duration over the run, measured by `dispatchTimingMiddleware` (`src/common/dispatch-timing.ts`) around `next(action)`. It is the time the main thread spent unable to paint or handle input because a dispatch was in progress — the quantity [INP](https://web.dev/articles/inp) penalizes.
+
+**It measures where work runs, not how much there is.** react-redux notifies every subscriber synchronously inside `dispatch`, so on `master` this number tracks the real cost. But any change that moves the notification pass out of the synchronous window — deferring it to a macrotask, time-slicing it — makes `Blocked` collapse toward zero *without removing a single unit of work*.
+
+A drop from `8704 ms` to `4 ms` is therefore not a 2000× speedup, and reporting it as one will not survive review. Always read `Blocked` alongside `Script` and `Task` from the CDP table, which do account for total work:
+
+| what changed | `Blocked` | `Script` / `Task` |
+|---|---|---|
+| work genuinely eliminated | down | down |
+| work relocated off the dispatch path | **down hard** | flat (or slightly up) |
+| work added | up | up |
+
+Both are worth optimizing — responsiveness and throughput are different goals — but they are different claims and the table should make that visible.
+
 ## Adding a benchmark
 
 Benchmarks live in `src/scenarios/`. Each benchmark must render a React component:

--- a/runBenchmarks.ts
+++ b/runBenchmarks.ts
@@ -328,7 +328,15 @@ function printBenchmarkResults(
 
   // React table
   const reactTable: any = new Table({
-    head: ['Version', 'Mount', 'Avg Upd', 'p95 Upd', 'Renders', 'Dispatches (avg)'],
+    head: [
+      'Version',
+      'Mount',
+      'Avg Upd',
+      'p95 Upd',
+      'Renders',
+      'Dispatches (avg)',
+      'Blocked',
+    ],
     style: { head: ['red'] },
     colAligns,
   })
@@ -341,9 +349,18 @@ function printBenchmarkResults(
       s.react.p95UpdateTime?.toFixed(1) ?? 'N/A',
       s.react.renderCount,
       `${s.dispatch.count} (${s.dispatch.avgTime.toFixed(2)})`,
+      s.dispatch.totalTime.toFixed(0),
     ])
   }
   console.log(reactTable.toString())
+  console.log(
+    chalk.gray(
+      '  Blocked = total ms spent inside dispatch() — main thread unavailable.\n' +
+        '  It measures WHERE work runs, not how much: deferring the subscriber\n' +
+        '  notification collapses it without removing work. Read it next to\n' +
+        '  Script/Task, which do show total cost.',
+    ),
+  )
 
   // Profile table (only when --profile)
   if (showProfile) {


### PR DESCRIPTION
`dispatchStats.totalTime` was already being collected — it just never made it into the output. This adds it to the React table as `Blocked`.

It's the sum of every `dispatch()` call over the run, i.e. how long the main thread was unavailable to paint or handle input. That's the thing INP penalizes, and right now you have to multiply `count × avg` by hand to get it.

```
┌─────────┬───────┬─────────┬─────────┬─────────┬──────────────────┬─────────┐
│ Version │ Mount │ Avg Upd │ p95 Upd │ Renders │ Dispatches (avg) │ Blocked │
├─────────┼───────┼─────────┼─────────┼─────────┼──────────────────┼─────────┤
│ 9.2.0   │  29.4 │    11.0 │    20.3 │      31 │        29 (1.24) │      36 │
└─────────┴───────┴─────────┴─────────┴─────────┴──────────────────┴─────────┘
```

The reason I also added a README section rather than just the column: this number is easy to misread. It measures *where* work runs, not how much of it there is. Anything that defers the subscriber notification off the synchronous path makes it collapse toward zero without removing any work — I've seen 8704 ms → 4 ms quoted from a branch that did exactly that, and it isn't a 2000× speedup. The note tells you to read it next to `Script`/`Task`, which do account for total cost.

No behaviour change, one extra column.